### PR TITLE
AI per-turn point gain reduced

### DIFF
--- a/src/main/java/leo/server/AI.java
+++ b/src/main/java/leo/server/AI.java
@@ -32,7 +32,7 @@ public class AI {
     private final Castle castle;
     private final Castle enemyCastle;
     private int turns = 0;
-    private int points;
+    private long points;
     private short want;
     private int diminish;
     private final DNA dna;
@@ -122,11 +122,21 @@ public class AI {
                     unit.getScript().perform();
             }
             turns++;
-            points += (21 + (4 * level)) + 100;
+            points += calculatePointsIncrease(level, turns);
 
         } catch (Exception e) {
             Log.error("Script Error3: " + lastUnit + ", " + e);
         }
+    }
+
+    public static long calculatePointsIncrease(int aiLevel, int turnCount) {
+        var exhaustionRatio = (double) (aiLevel+9) / (aiLevel+10);
+        var exhaustionFactor = Math.pow(exhaustionRatio, turnCount);
+
+        // Mostly trying to keep the original formula, but with some shifts
+        var minimumIncrease = 20 + aiLevel * 2;
+
+        return Math.round((101 + (4 * aiLevel)) * exhaustionFactor) + minimumIncrease;
     }
 
 

--- a/src/test/java/leo/server/AITest.java
+++ b/src/test/java/leo/server/AITest.java
@@ -1,0 +1,41 @@
+package leo.server;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AITest {
+
+    @Test
+    void calculatePointsIncrease() {
+        // Balance checks. When changing the method, consider these requirements, or adapt them.
+
+        // On level 1:
+        // Tutorial-type of game
+        // When starting out, about one medium (150 points) unit per turn is acceptable (maybe even less)
+        assertTrue(AI.calculatePointsIncrease(1, 1) > 110);
+        assertTrue(AI.calculatePointsIncrease(1, 1) < 150);
+
+        // Around turn 10, already more than two turns per medium unit
+        assertTrue(AI.calculatePointsIncrease(1, 10) > 60);
+        assertTrue(AI.calculatePointsIncrease(1, 10) < 75);
+
+        // major exhaustion by very late game
+        assertTrue(AI.calculatePointsIncrease(1, 100) < 30);
+        assertTrue(AI.calculatePointsIncrease(1, 100) > 20);
+
+        // On level 100:
+        // One top-tier (550 points) unit per turn
+        assertTrue(AI.calculatePointsIncrease(100, 1) > 550);
+        assertTrue(AI.calculatePointsIncrease(100, 1) < 1000);
+
+        // Maintain that strength around turn 10
+        assertTrue(AI.calculatePointsIncrease(100, 10) > 550);
+        assertTrue(AI.calculatePointsIncrease(100, 10) < 1000);
+
+        // Still rolling out high power, wizard-level (350 points) units in very late game
+        assertTrue(AI.calculatePointsIncrease(100, 100) < 550);
+        assertTrue(AI.calculatePointsIncrease(100, 100) > 350);
+
+    }
+}


### PR DESCRIPTION
Attempt to fix #4 somewhat - the point budget is not increasing at a constant rate per turn, but a decreasing one ("exhaustion" mechanic).