### PR TITLE
Re-adding missing non-filtered resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,9 @@
     <build>
         <resources>
             <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
                 <directory>src/main/resources-filtered</directory>
                 <filtering>true</filtering>
             </resource>


### PR DESCRIPTION
The game was missing all the art as a result of overriding the default resource directory.