### PR TITLE
Surrendering tutorial is now skipping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - browser-starting code improved
 - logging now more consistent, and done using Tinylog library
 - server in standalone-client mode now runs as a thread instead of a process
+- surrendering the tutorial game was made into skipping the tutorial instead
 
 # 1.1.2
 

--- a/src/main/java/leo/client/Client.java
+++ b/src/main/java/leo/client/Client.java
@@ -31,7 +31,7 @@ public class Client {
     //public static final int  SCREEN_WIDTH = 800; //moved to "leo/shared/Constants.java"
     //public static final int  SCREEN_HEIGHT = 600; //moved to "leo/shared/Constants.java"
     public static final String VERSION = getGameVersion();
-    public static final String PROTOCOL_VERSION = "1.1.0";
+    public static final String PROTOCOL_VERSION = "1.1.3";
     public static final String TITLE = "Zatikon ";
     public static final String CREDITS = " Chronic Logic 2023";
 //    public static final String SERVER_NAME = "localhost";

--- a/src/main/java/leo/client/SurrenderButton.java
+++ b/src/main/java/leo/client/SurrenderButton.java
@@ -53,10 +53,14 @@ public class SurrenderButton extends LeoComponent {
         if (pressed) return false;
         pressed = true;
         Client.getNetManager().sendAction(Action.SURRENDER, (byte) 0, (byte) 0);
-        Client.getGameData().getMyCastle().getObserver().endGame(Client.getGameData().getEnemyCastle());
+        var whoWins = isTutorialGame() ? Client.getGameData().getMyCastle() : Client.getGameData().getEnemyCastle();
+        Client.getGameData().getMyCastle().getObserver().endGame(whoWins);
         return true;
     }
 
+    private boolean isTutorialGame() {
+        return Client.getGameData().getEnemyRating() == 1;
+    }
 
     //////////////////////////////////////////////////////////////////
     // Get the message
@@ -64,6 +68,8 @@ public class SurrenderButton extends LeoComponent {
     public String getMessage() {
         if (confirming)
             return "You sure?";
+        else if (isTutorialGame())
+            return "Skip tutorial";
         else
             return "Surrender";
 

--- a/src/main/java/leo/server/game/TutorialGame.java
+++ b/src/main/java/leo/server/game/TutorialGame.java
@@ -204,6 +204,10 @@ public class TutorialGame implements Game {
         endGame(castle2);
     }
 
+    public void skipTutorial() {
+        endGame(castle1);
+    }
+
 
     /////////////////////////////////////////////////////////////////
     // Resynch me
@@ -402,7 +406,7 @@ public class TutorialGame implements Game {
                 break;
 
             case Action.SURRENDER:
-                disconnect(player);
+                skipTutorial();
                 break;
         }
 


### PR DESCRIPTION
A bit of a hack, but for now the easiest way to implement skipping the tutorial. The hack is mostly regarding introducing more calls to the Client's static methods - conceptually it's fine in the sense of surrendering not being very meaningful in a tutorial game.

Solves #12.